### PR TITLE
Add explicit depends_on to helm_release resource

### DIFF
--- a/helm/resource_release_test.go
+++ b/helm/resource_release_test.go
@@ -529,6 +529,7 @@ func testAccHelmReleaseConfigRepository(resource, ns, name string) string {
 			namespace  = %q
 			repository = "${helm_repository.stable_repo.metadata.0.name}"
 			chart      = "coredns"
+			depends_on = [helm_repository.stable_repo]
 		}
 	`, resource, name, ns)
 }


### PR DESCRIPTION
Applies to the TestAccResourceRelease_repository test case where a
helm_repository resource is being used

Should address: https://travis-ci.org/terraform-providers/terraform-provider-helm/jobs/638489411

Related to: https://github.com/aaronmell/terraform-provider-helm/pull/9#issuecomment-575708286